### PR TITLE
Enhance support for pid encoding

### DIFF
--- a/src/lager2json.erl
+++ b/src/lager2json.erl
@@ -91,6 +91,10 @@ format_test_() ->
       <<"{\"message\":\"hallo world\",\"metadata\":{\"pid\":\"", Pid/binary, "\"},\"severity\":\"info\",\"timestamp\":\"", TimeStamp/binary, "\"}">>,
       format(lager_msg:new("hallo world", Now, info, [{pid, io_lib:format("~p", [Self])}], []), [])
     )},
+   {"bare pid in metadata", ?_assertEqual(
+                          <<"{\"message\":\"hallo world\",\"metadata\":{\"pid\":\"<0.6.0>\"},\"severity\":\"info\",\"timestamp\":\"", TimeStamp/binary, "\"}">>,
+                          format(lager_msg:new("hallo world", Now, info, [{pid, list_to_pid("<0.6.0>")}], []), [])
+     )},
     {"file in metadata", ?_assertEqual(
       <<"{\"message\":\"hallo world\",\"metadata\":{\"file\":\"foo.erl\"},\"severity\":\"info\",\"timestamp\":\"", TimeStamp/binary, "\"}">>,
       format(lager_msg:new("hallo world", Now, info, [{file, "foo.erl"}], []), [])

--- a/src/lager2json.erl
+++ b/src/lager2json.erl
@@ -51,7 +51,7 @@ metadata(Msg) ->
 printable({file, File}) ->
   {file, unicode:characters_to_binary(File, unicode)};
 printable({pid, Pid}) ->
-  {pid, unicode:characters_to_binary(Pid, unicode)};
+    {pid, pid_list(Pid)};
 %% if a value is expressable in json use it directly, otherwise
 %% try to get a printable representation and express it as a json
 %% string
@@ -61,6 +61,12 @@ printable({Key, Value}) when is_atom(Key); is_binary(Key) ->
     false -> {Key, unicode:characters_to_binary(io_lib:format("~p", [Value]), unicode)}
   end.
 
+pid_list(Pid) ->
+  try unicode:characters_to_binary(Pid, unicode) of
+    Pid0 -> Pid0
+    catch error:badarg ->
+      unicode:characters_to_binary(hd(io_lib:format("~p", [Pid])), unicode)
+    end.
 
 -ifdef(TEST).
 


### PR DESCRIPTION
I hit some issues when integrating this with encoding pids,
especially during startup and shutdown.

This PR adds a more tolerant pid encoder which, if it fails the
original path, will encode it a different more burtalist way.
